### PR TITLE
feat: add color_thresholds for numeric-state marker colors

### DIFF
--- a/Home-Assistant-3D-Floorplan.js
+++ b/Home-Assistant-3D-Floorplan.js
@@ -425,6 +425,46 @@ class HomeAssistant3DFloorplan extends HTMLElement {
     return "state-neutral";
   }
 
+  /**
+   * Normalizes a raw color_thresholds config array into a sorted, validated array.
+   * Each entry must have a numeric `value` and a CSS color string `color`.
+   * Entries are sorted ascending by value so threshold lookup is deterministic.
+   * Invalid entries (missing value or color) are silently dropped.
+   */
+  _normalizeColorThresholds(raw) {
+    if (!Array.isArray(raw) || raw.length === 0) return null;
+    const entries = raw
+      .map((entry) => ({ value: Number(entry?.value), color: String(entry?.color || "").trim() }))
+      .filter((entry) => Number.isFinite(entry.value) && entry.color.length > 0);
+    if (entries.length === 0) return null;
+    return entries.sort((a, b) => a.value - b.value);
+  }
+
+  /**
+   * Given a sorted color_thresholds array and a numeric state value, returns the
+   * CSS color string for the appropriate threshold band.
+   *
+   * Threshold semantics (step, not interpolated):
+   *   - Below the first threshold value  → first threshold color
+   *   - Between thresholds N and N+1     → threshold N color
+   *   - At or above the last threshold   → last threshold color
+   *
+   * Example with thresholds [{value:18, color:"blue"}, {value:22, color:"green"}, {value:26, color:"red"}]:
+   *   state 15  → blue   (below first threshold)
+   *   state 20  → blue   (between 18 and 22, i.e., >= 18 but < 22)
+   *   state 22  → green  (>= 22 but < 26)
+   *   state 30  → red    (>= last threshold)
+   */
+  _markerColorFromThresholds(thresholds, numericState) {
+    if (!thresholds || thresholds.length === 0 || !Number.isFinite(numericState)) return null;
+    // Walk from highest to lowest; return color of the first threshold <= state
+    for (let i = thresholds.length - 1; i >= 0; i--) {
+      if (numericState >= thresholds[i].value) return thresholds[i].color;
+    }
+    // State is below all thresholds — use the lowest threshold color
+    return thresholds[0].color;
+  }
+
   _markerIcon(row) {
     const markerIcon = this._markers[row.key]?.icon;
     if (markerIcon) return markerIcon;
@@ -603,6 +643,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
         _configLightShapeExplicit: marker.light_shape !== undefined || marker.lightShape !== undefined,
         _configLightRectExplicit: marker.light_rect !== undefined || marker.lightRect !== undefined,
         _configLightPathExplicit: marker.light_path !== undefined || marker.lightPath !== undefined,
+        colorThresholds: this._normalizeColorThresholds(marker.color_thresholds || marker.colorThresholds),
         x: Number(point.x),
         y: Number(point.y),
         z: Number(point.z),
@@ -640,6 +681,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
         ...(marker._configLightShapeExplicit ? { _configLightShapeExplicit: true } : {}),
         ...(marker._configLightRectExplicit ? { _configLightRectExplicit: true } : {}),
         ...(marker._configLightPathExplicit ? { _configLightPathExplicit: true } : {}),
+        colorThresholds: this._normalizeColorThresholds(marker.colorThresholds || marker.color_thresholds),
         x: is3DMarker ? x : Math.max(0, Math.min(100, x)),
         y: is3DMarker ? y : Math.max(0, Math.min(100, y)),
         ...(is3DMarker ? { z } : {}),
@@ -4508,10 +4550,17 @@ class HomeAssistant3DFloorplan extends HTMLElement {
     const content = this._markerFace(row);
     const stateClass = this._stateClass(row);
     const title = this._config.show_entity_state ? `${row.name} - ${row.primaryState}` : row.name;
+    const thresholds = marker?.colorThresholds;
+    const numericState = Number(row.primaryState);
+    const thresholdColor = (!row.offline && thresholds && Number.isFinite(numericState))
+      ? this._markerColorFromThresholds(thresholds, numericState)
+      : null;
+    const thresholdClass = thresholdColor ? "state-threshold" : "";
+    const thresholdStyle = thresholdColor ? ` --marker-threshold-color: ${thresholdColor};` : "";
     return `
       <button
-        class="marker ${this._display.showLabels ? "with-label" : "icon-only"} ${content.type === "value" ? "value-marker" : ""} ${this._config.show_entity_state ? "state-mode" : ""} ${stateClass} ${isEditing && this._selectedMarkers.has(row.key) ? "selected" : ""} ${row.offline ? "offline" : "online"}"
-        style="left: ${this._escape(marker.x)}%; top: ${this._escape(marker.y)}%; --marker-size: ${this._escape(size)}px;"
+        class="marker ${this._display.showLabels ? "with-label" : "icon-only"} ${content.type === "value" ? "value-marker" : ""} ${this._config.show_entity_state ? "state-mode" : ""} ${stateClass} ${thresholdClass} ${isEditing && this._selectedMarkers.has(row.key) ? "selected" : ""} ${row.offline ? "offline" : "online"}"
+        style="left: ${this._escape(marker.x)}%; top: ${this._escape(marker.y)}%; --marker-size: ${this._escape(size)}px;${thresholdStyle}"
         draggable="${isEditing ? "true" : "false"}"
         data-marker="${this._escape(row.key)}"
         data-entity="${this._escape(row.entityId)}"
@@ -5340,11 +5389,17 @@ class HomeAssistant3DFloorplan extends HTMLElement {
       button.type = "button";
       const stateClass = this._stateClass(row);
       const content = this._markerFace(row);
-      button.className = `model-marker ${this._display.showLabels ? "with-label" : "icon-only"} ${content.type === "value" ? "value-marker" : ""} ${stateClass} ${row.offline ? "offline" : "online"}`;
+      const thresholds = marker?.colorThresholds;
+      const numericState = Number(row.primaryState);
+      const thresholdColor = (!row.offline && thresholds && Number.isFinite(numericState))
+        ? this._markerColorFromThresholds(thresholds, numericState)
+        : null;
+      button.className = `model-marker ${this._display.showLabels ? "with-label" : "icon-only"} ${content.type === "value" ? "value-marker" : ""} ${stateClass} ${thresholdColor ? "state-threshold" : ""} ${row.offline ? "offline" : "online"}`;
       button.dataset.marker = row.key;
       button.dataset.entity = row.entityId;
       button.title = `${row.name} - ${row.primaryState}`;
       button.style.setProperty("--marker-size", `${this._display.markerSize}px`);
+      if (thresholdColor) button.style.setProperty("--marker-threshold-color", thresholdColor);
       button.innerHTML = `
         <span class="${content.type === "value" ? "value-face" : ""}">${content.type === "value" ? this._escape(content.value) : `<ha-icon icon="${this._escape(content.icon)}"></ha-icon>`}</span>
         ${this._display.showLabels ? `<strong>${this._escape(row.name)}</strong>` : ""}
@@ -9405,6 +9460,12 @@ class HomeAssistant3DFloorplan extends HTMLElement {
           box-shadow: 0 0 0 3px rgba(212, 54, 54, 0.98), 0 0 18px rgba(212, 54, 54, 0.95);
         }
 
+        /* color_thresholds: overrides state-based background with the computed threshold color */
+        .model-marker.state-threshold span {
+          background: var(--marker-threshold-color);
+          color: #fff;
+        }
+
         .model-sub-spot {
           background: rgba(248, 214, 109, 0.95);
           color: #111827;
@@ -9992,6 +10053,13 @@ class HomeAssistant3DFloorplan extends HTMLElement {
           background: var(--dmp-bad);
           color: #fff;
           box-shadow: 0 0 0 3px rgba(212, 54, 54, 0.98), 0 0 18px rgba(212, 54, 54, 0.95);
+        }
+
+        /* color_thresholds: overrides state-based background with the computed threshold color */
+        .marker.state-threshold span,
+        .marker.state-mode.state-threshold span {
+          background: var(--marker-threshold-color);
+          color: #fff;
         }
 
         .marker ha-icon {

--- a/README.md
+++ b/README.md
@@ -86,6 +86,34 @@ Temperature and humidity sensors show their live value on the marker. Use **Mark
 marker_display: value   # auto | icon | value
 ```
 
+### Color Thresholds
+
+Use `color_thresholds` to color a marker dynamically based on its numeric state value. This is particularly useful for temperature, humidity, CO₂, or any sensor with a continuous numeric reading.
+
+```yaml
+markers:
+  - entity: sensor.living_room_temperature
+    name: Living Room
+    marker_display: value
+    color_thresholds:
+      - value: 18
+        color: "#42a5f5"   # blue  — cold
+      - value: 22
+        color: "#66bb6a"   # green — comfortable
+      - value: 26
+        color: "#ef5350"   # red   — hot
+```
+
+**Threshold logic (step, not interpolated):**
+
+- State **below** the first threshold → first threshold color
+- State **between** two thresholds → color of the lower threshold
+- State **at or above** the last threshold → last threshold color
+
+So for the example above: values below 18 are blue, 18–21.9 are blue, 22–25.9 are green, and 26+ are red.
+
+`color_thresholds` works in both 2D (floorplan image) and 3D model view, and accepts any valid CSS color (`#hex`, `rgb()`, named colors). When the entity is offline or unavailable, the standard red offline styling takes precedence.
+
 ## Edit Mode
 
 Switch to Edit Mode to place and configure markers.


### PR DESCRIPTION
## Summary

Adds a color_thresholds config option to markers that maps numeric entity state values to CSS colors. This enables dynamic per-marker coloring driven by the live sensor reading — useful for temperature, humidity, CO₂, and any other numeric sensor.

## Usage

\\\yaml
markers:
  - entity: sensor.cocina_temperature_2
    name: Cocina
    marker_display: value
    color_thresholds:
      - value: 18
        color: '#42a5f5'   # blue  — cold
      - value: 22
        color: '#66bb6a'   # green — comfortable
      - value: 26
        color: '#ef5350'   # red   — hot
\\\

**Threshold semantics (step, not interpolated):**
- State below first threshold → first threshold color
- State between two thresholds → color of the lower threshold
- State at or above the last threshold → last threshold color

Works in both 2D floorplan and 3D model views. Offline/unavailable state always wins (standard red styling takes priority).

## Changes

- \_markersFromList\ / \_normalizedMarkers\: parse and store \colorThresholds\ (accepts both \color_thresholds\ and \colorThresholds\ key names for consistency with the rest of the codebase)
- \_normalizeColorThresholds()\: validates entries and sorts by value ascending
- \_markerColorFromThresholds()\: step-based color lookup
- \_markerTemplate()\ (2D) and \_build3DMarkerButtons()\ (3D): inject \--marker-threshold-color\ CSS custom property and \state-threshold\ class when thresholds resolve to a color
- CSS: \.state-threshold span\ rules for both \.marker\ and \.model-marker\, overriding the default state color with the custom property
- README: documents the feature with example config and explanation of threshold semantics