### PR TITLE
feat: add navigate action for markers and interactive objects

### DIFF
--- a/Home-Assistant-3D-Floorplan.js
+++ b/Home-Assistant-3D-Floorplan.js
@@ -653,6 +653,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
         markerDisplay: this._normalizeMarkerDisplay(marker.marker_display || marker.markerDisplay),
         tapAction: this._normalizeMarkerAction(marker.tap_action || marker.tapAction, "tap"),
         holdAction: this._normalizeMarkerAction(marker.hold_action || marker.holdAction, "hold"),
+        navigationPath: this._normalizeNavigationPath(marker.navigation_path || marker.navigationPath),
         lightIntensity: this._normalizeLightIntensity(marker.light_intensity ?? marker.lightIntensity),
         lightType: this._normalizeLightType(marker.light_type ?? marker.lightType),
         lightRadius: this._normalizeLightRadius(marker.light_radius ?? marker.lightRadius),
@@ -691,6 +692,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
         markerDisplay: this._normalizeMarkerDisplay(marker.markerDisplay || marker.marker_display),
         tapAction: this._normalizeMarkerAction(marker.tapAction || marker.tap_action, "tap"),
         holdAction: this._normalizeMarkerAction(marker.holdAction || marker.hold_action, "hold"),
+        navigationPath: this._normalizeNavigationPath(marker.navigationPath || marker.navigation_path),
         lightIntensity: this._normalizeLightIntensity(marker.lightIntensity ?? marker.light_intensity),
         lightType: this._normalizeLightType(marker.lightType ?? marker.light_type),
         lightRadius: this._normalizeLightRadius(marker.lightRadius ?? marker.light_radius),
@@ -3768,6 +3770,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
     const base = [
       ["toggle", "Toggle"],
       ["more-info", "More info"],
+      ["navigate", "Navigate"],
       ["none", "None"],
     ];
     if (type === "hold") {
@@ -4758,6 +4761,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
                     ...(marker.markerDisplay ? [`        marker_display: ${marker.markerDisplay}`] : []),
                     `        tap_action: ${marker.tapAction}`,
                     `        hold_action: ${marker.holdAction}`,
+                    ...(marker.navigationPath ? [`        navigation_path: ${marker.navigationPath}`] : []),
                     ...(marker.lightIntensity !== "" ? [`        light_intensity: ${marker.lightIntensity}`] : []),
                     ...(marker.lightType ? [`        light_type: ${this._threeLightTypeName(marker.lightType)}`, `        light_radius: ${marker.lightRadius || 1.5}`] : []),
                     ...(marker.lightPreset ? [`        light_preset: ${marker.lightPreset}`] : []),
@@ -4827,6 +4831,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
               ...(marker.markerDisplay ? [`    marker_display: ${marker.markerDisplay}`] : []),
               `    tap_action: ${marker.tapAction}`,
               `    hold_action: ${marker.holdAction}`,
+              ...(marker.navigationPath ? [`    navigation_path: ${marker.navigationPath}`] : []),
               ...(marker.lightIntensity !== "" ? [`    light_intensity: ${marker.lightIntensity}`] : []),
               ...(marker.lightType ? [`    light_type: ${this._threeLightTypeName(marker.lightType)}`, `    light_radius: ${marker.lightRadius || 1.5}`] : []),
               ...(marker.lightPreset ? [`    light_preset: ${marker.lightPreset}`] : []),
@@ -4943,6 +4948,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
           markerDisplay: this._normalizeMarkerDisplay(marker.markerDisplay || marker.marker_display),
           tapAction: this._exportMarkerAction(row, marker, "tap"),
           holdAction: this._exportMarkerAction(row, marker, "hold"),
+          navigationPath: this._normalizeNavigationPath(marker.navigationPath || marker.navigation_path),
           lightIntensity: row?.primaryDomain === "light" || hasCustomLightIntensity ? this._normalizeLightIntensity(marker.lightIntensity) : "",
           lightType: this._normalizeLightType(marker.lightType),
           lightRadius: this._normalizeLightRadius(marker.lightRadius),
@@ -5289,6 +5295,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
           entity: iObj.entity,
           tapAction: iObj.tap_action || "toggle",
           holdAction: iObj.hold_action || "more-info",
+          navigationPath: this._normalizeNavigationPath(iObj.navigation_path || iObj.navigationPath),
           stateStyles: iObj.state_styles || {},
           originalMaterials,
           lastAppliedState: null,
@@ -5422,7 +5429,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
                 const elapsed = performance.now() - pointerStart.time;
                 const holdMs = Math.max(250, Number(this._config.marker_hold_ms) || 650);
                 const action = elapsed >= holdMs ? entry.holdAction : entry.tapAction;
-                this._runInteractiveObjectAction(action, entry.entity);
+                this._runInteractiveObjectAction(action, entry.entity, entry.navigationPath);
                 pointerStart = null;
                 return;
               }
@@ -5853,6 +5860,10 @@ class HomeAssistant3DFloorplan extends HTMLElement {
       this._toggleEntity(row.entityId);
       return;
     }
+    if (normalizedAction === "navigate") {
+      this._navigate(this._markers?.[row.key]?.navigationPath || row.navigationPath);
+      return;
+    }
     if (normalizedAction === "select") {
       this._selectedMarkers.clear();
       this._selectedMarkers.add(row.key);
@@ -5868,6 +5879,23 @@ class HomeAssistant3DFloorplan extends HTMLElement {
     }
   }
 
+  _normalizeNavigationPath(value) {
+    return String(value ?? "").trim();
+  }
+
+  _navigate(path) {
+    const target = this._normalizeNavigationPath(path);
+    if (!target) return false;
+    if (target.startsWith("#")) {
+      // Hash targets drive pop-up cards (e.g. Bubble Card) without a route change.
+      window.location.hash = target.slice(1);
+    } else {
+      window.history.pushState(null, "", target);
+    }
+    window.dispatchEvent(new Event("location-changed", { bubbles: true, composed: true }));
+    return true;
+  }
+
   _openMoreInfo(entityId) {
     if (!entityId) return;
     const moreInfoEvent = new Event("hass-more-info", { bubbles: true, composed: true });
@@ -5880,7 +5908,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
     this._hass.callService("homeassistant", "toggle", { entity_id: entityId });
   }
 
-  _runInteractiveObjectAction(action, entityId) {
+  _runInteractiveObjectAction(action, entityId, navigationPath) {
     const normalized = action || "more-info";
     if (normalized === "none") return;
     if (normalized === "more-info") {
@@ -5889,6 +5917,14 @@ class HomeAssistant3DFloorplan extends HTMLElement {
     }
     if (normalized === "toggle") {
       this._toggleEntity(entityId);
+      return;
+    }
+    if (normalized === "navigate") {
+      this._navigate(navigationPath);
+      return;
+    }
+    if (typeof normalized === "object" && normalized.action === "navigate") {
+      this._navigate(normalized.navigation_path || normalized.navigationPath);
       return;
     }
     // Support call-service action: { action: "call-service", service: "...", data: {...} }
@@ -11685,6 +11721,7 @@ class HomeAssistant3DFloorplanEditor extends HTMLElement {
       ["auto", "Auto"],
       ["toggle", "Toggle"],
       ["more-info", "More info"],
+      ["navigate", "Navigate"],
       ["none", "None"],
     ];
     return type === "hold" ? [...options, ["move", "Move"], ["select", "Select"]] : options;

--- a/test/navigate-action.test.mjs
+++ b/test/navigate-action.test.mjs
@@ -1,0 +1,219 @@
+// Tests for the `navigate` marker/interactive-object action added on top of
+// Hollako/Home-Assistant-3D-Floorplan v2.10.0.
+//
+// The card ships as a browser ES module with no exports: it defines two custom
+// elements as a side effect of import. So we stub just enough DOM to import it,
+// capture the class off customElements.define, and exercise methods on bare
+// prototypes — no full card construction, no three.js, no renderer.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// ---------------------------------------------------------------- DOM stubs
+const fired = [];      // events dispatched on window
+const pushed = [];     // history.pushState calls
+const defined = new Map();
+
+globalThis.HTMLElement = class {
+  attachShadow() { return {}; }
+  addEventListener() {}
+  dispatchEvent() { return true; }
+};
+globalThis.customElements = { define: (name, cls) => defined.set(name, cls) };
+globalThis.document = { createElement: (tag) => ({ tag }) };
+// Browsers normalise `location.hash = "x"` to "#x" and fire hashchange only on a
+// real change — emulate that so the assertions below mean what they say.
+const hashChanges = [];
+const location = {
+  _hash: "",
+  get hash() { return this._hash; },
+  set hash(value) {
+    const next = value === "" ? "" : value.startsWith("#") ? value : `#${value}`;
+    if (next === this._hash) return;
+    this._hash = next;
+    hashChanges.push(next);
+  },
+};
+
+globalThis.window = {
+  location,
+  history: { pushState: (state, title, url) => pushed.push(url) },
+  dispatchEvent: (event) => { fired.push(event); return true; },
+  addEventListener() {},
+  customCards: [],
+};
+
+await import("../Home-Assistant-3D-Floorplan.js");
+const Card = defined.get("home-assistant-3d-floorplan");
+const Editor = defined.get("home-assistant-3d-floorplan-editor");
+
+// ------------------------------------------------------------------ helpers
+function makeCard(overrides = {}) {
+  const card = Object.create(Card.prototype);
+  card._config = {};
+  card._markers = {};
+  card._serviceCalls = [];
+  card._moreInfo = [];
+  card._hass = {
+    callService: (domain, service, data) => card._serviceCalls.push([domain, service, data]),
+  };
+  card.dispatchEvent = (event) => { card._moreInfo.push(event); return true; };
+  return Object.assign(card, overrides);
+}
+
+function reset() {
+  fired.length = 0;
+  pushed.length = 0;
+  hashChanges.length = 0;
+  location._hash = "";
+}
+
+const locationChanged = () => fired.filter((e) => e.type === "location-changed");
+
+// -------------------------------------------------------------- vocabulary
+test("navigate is offered as a tap action", () => {
+  const card = makeCard();
+  const tap = card._markerActionOptions("tap").map(([value]) => value);
+  assert.ok(tap.includes("navigate"), `tap options were ${tap.join(", ")}`);
+});
+
+test("navigate is offered as a hold action too", () => {
+  const card = makeCard();
+  assert.ok(card._markerActionOptions("hold").map(([v]) => v).includes("navigate"));
+});
+
+test("navigate survives config normalisation", () => {
+  const card = makeCard();
+  assert.equal(card._normalizeMarkerAction("navigate", "tap"), "navigate");
+  assert.equal(card._normalizeMarkerAction("navigate", "hold"), "navigate");
+});
+
+test("unknown actions are still rejected", () => {
+  const card = makeCard();
+  assert.equal(card._normalizeMarkerAction("launch-missiles", "tap"), "");
+});
+
+test("the visual editor dropdown offers navigate", () => {
+  const editor = Object.create(Editor.prototype);
+  assert.ok(editor._actionOptions("tap").map(([v]) => v).includes("navigate"));
+});
+
+// ------------------------------------------------------------- hash targets
+test("a hash target sets location.hash and fires location-changed", () => {
+  reset();
+  const card = makeCard({ _markers: { "light.living": { navigationPath: "#living-room" } } });
+  card._runMarkerAction("navigate", { key: "light.living", entityId: "light.living" });
+  assert.equal(location.hash, "#living-room");
+  assert.deepEqual(hashChanges, ["#living-room"], "exactly one hashchange");
+  assert.equal(locationChanged().length, 1);
+  assert.equal(pushed.length, 0, "hash targets must not push a history entry");
+});
+
+// ------------------------------------------------------------- path targets
+test("a dashboard path pushes history and fires location-changed", () => {
+  reset();
+  const card = makeCard({ _markers: { "light.a": { navigationPath: "/lovelace/house" } } });
+  card._runMarkerAction("navigate", { key: "light.a", entityId: "light.a" });
+  assert.deepEqual(pushed, ["/lovelace/house"]);
+  assert.equal(locationChanged().length, 1);
+});
+
+// ------------------------------------------------------------------- guards
+test("navigate with no configured path is a no-op, not a crash", () => {
+  reset();
+  const card = makeCard({ _markers: { "light.a": {} } });
+  card._runMarkerAction("navigate", { key: "light.a", entityId: "light.a" });
+  assert.equal(locationChanged().length, 0);
+  assert.equal(pushed.length, 0);
+  assert.equal(location.hash, "");
+});
+
+test("_navigate reports whether it navigated", () => {
+  reset();
+  const card = makeCard();
+  assert.equal(card._navigate("   "), false);
+  assert.equal(card._navigate("#kitchen"), true);
+});
+
+// -------------------------------------------------- existing actions intact
+test("toggle still calls homeassistant.toggle", () => {
+  reset();
+  const card = makeCard();
+  card._runMarkerAction("toggle", { key: "light.a", entityId: "light.a" });
+  assert.deepEqual(card._serviceCalls, [["homeassistant", "toggle", { entity_id: "light.a" }]]);
+  assert.equal(locationChanged().length, 0);
+});
+
+test("more-info still fires hass-more-info", () => {
+  reset();
+  const card = makeCard();
+  card._runMarkerAction("more-info", { key: "s.a", entityId: "sensor.a" });
+  assert.equal(card._moreInfo.length, 1);
+  assert.equal(card._moreInfo[0].type, "hass-more-info");
+  assert.deepEqual(card._moreInfo[0].detail, { entityId: "sensor.a" });
+});
+
+test("none still does nothing", () => {
+  reset();
+  const card = makeCard();
+  card._runMarkerAction("none", { key: "light.a", entityId: "light.a" });
+  assert.equal(card._serviceCalls.length, 0);
+  assert.equal(card._moreInfo.length, 0);
+  assert.equal(locationChanged().length, 0);
+});
+
+// ------------------------------------------------- interactive mesh objects
+test("clickable meshes navigate via the third argument", () => {
+  reset();
+  const card = makeCard();
+  card._runInteractiveObjectAction("navigate", "light.a", "#media-room");
+  assert.equal(location.hash, "#media-room");
+});
+
+test("clickable meshes navigate via the object form", () => {
+  reset();
+  const card = makeCard();
+  card._runInteractiveObjectAction({ action: "navigate", navigation_path: "#basement" }, "light.a");
+  assert.equal(location.hash, "#basement");
+});
+
+test("mesh call-service is untouched", () => {
+  reset();
+  const card = makeCard();
+  card._runInteractiveObjectAction(
+    { action: "call-service", service: "script.movie_night", data: { x: 1 } },
+    "light.a",
+  );
+  assert.deepEqual(card._serviceCalls, [["script", "movie_night", { entity_id: "light.a", x: 1 }]]);
+});
+
+// ------------------------------------------------------- config round-trip
+test("navigation_path is read from YAML config (snake_case)", () => {
+  const card = makeCard();
+  const parsed = card._normalizedMarkers({
+    "light.kitchen": { entityId: "light.kitchen", x: 1, y: 2, z: 3, navigation_path: "#kitchen" },
+  });
+  assert.equal(parsed["light.kitchen"].navigationPath, "#kitchen");
+});
+
+test("navigation_path is written back out to YAML", () => {
+  const card = makeCard({
+    _activeFloorId: "ground",
+    _floorMarkers: {},
+    _markers: {
+      "light.kitchen": { entityId: "light.kitchen", x: 1, y: 2, navigationPath: "#kitchen" },
+    },
+  });
+  const rows = new Map([["light.kitchen", { key: "light.kitchen", entityId: "light.kitchen", name: "Kitchen", primaryDomain: "light" }]]);
+  const [exported] = card._yamlMarkersForFloor("ground", rows);
+  assert.equal(exported.navigationPath, "#kitchen");
+});
+
+test("re-tapping the same marker fires no second hashchange (known Bubble caveat)", () => {
+  reset();
+  const card = makeCard({ _markers: { "light.a": { navigationPath: "#kitchen" } } });
+  const row = { key: "light.a", entityId: "light.a" };
+  card._runMarkerAction("navigate", row);
+  card._runMarkerAction("navigate", row);
+  assert.deepEqual(hashChanges, ["#kitchen"], "browser suppresses the repeat hashchange");
+  assert.equal(locationChanged().length, 2, "but location-changed still fires each tap");
+});


### PR DESCRIPTION
Adds a `navigate` option to the existing tap/hold action vocabulary (`toggle` / `more-info` / `call-service` / `none`) for both markers and interactive objects.

## Why

Many dashboards organise room detail behind hash-addressable pop-up cards (e.g. Bubble Card) or sub-views. A `navigate` action lets a tap on a marker or mesh open that room's pop-up / route instead of toggling an entity — so the floorplan can act as the navigation surface for a larger dashboard.

## Behaviour

- `navigation_path: "#living-room"` — hash targets set `location.hash` (drives pop-up cards) without a route change.
- `navigation_path: "/lovelace/climate"` — path targets use `history.pushState`.
- Both dispatch `location-changed` so Home Assistant's router and pop-up cards react.
- Round-trips through the card's YAML export as `navigation_path`, and appears in the visual editor's action dropdowns.

```yaml
markers:
  - key: light.living_room
    entity: light.living_room
    tap_action: navigate
    navigation_path: "#living-room"
    hold_action: more-info
```

## Tests

Adds `test/navigate-action.test.mjs` — 18 tests, `node --test`, no dependencies (stubs `HTMLElement`/`customElements`/`window`, imports the card, exercises the prototypes directly — no three.js needed). Runs in ~150 ms.

One behavioural note pinned by the tests: re-tapping the same hash target fires no second `hashchange` (browser semantics — the hash is unchanged), but `location-changed` fires on every tap, which is why both dispatches are kept.