### PR TITLE
fix navigate action configuration

### DIFF
--- a/Home-Assistant-3D-Floorplan.js
+++ b/Home-Assistant-3D-Floorplan.js
@@ -4761,7 +4761,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
                     ...(marker.markerDisplay ? [`        marker_display: ${marker.markerDisplay}`] : []),
                     `        tap_action: ${marker.tapAction}`,
                     `        hold_action: ${marker.holdAction}`,
-                    ...(marker.navigationPath ? [`        navigation_path: ${marker.navigationPath}`] : []),
+                    ...(marker.navigationPath ? [`        navigation_path: ${JSON.stringify(marker.navigationPath)}`] : []),
                     ...(marker.lightIntensity !== "" ? [`        light_intensity: ${marker.lightIntensity}`] : []),
                     ...(marker.lightType ? [`        light_type: ${this._threeLightTypeName(marker.lightType)}`, `        light_radius: ${marker.lightRadius || 1.5}`] : []),
                     ...(marker.lightPreset ? [`        light_preset: ${marker.lightPreset}`] : []),
@@ -4831,7 +4831,7 @@ class HomeAssistant3DFloorplan extends HTMLElement {
               ...(marker.markerDisplay ? [`    marker_display: ${marker.markerDisplay}`] : []),
               `    tap_action: ${marker.tapAction}`,
               `    hold_action: ${marker.holdAction}`,
-              ...(marker.navigationPath ? [`    navigation_path: ${marker.navigationPath}`] : []),
+              ...(marker.navigationPath ? [`    navigation_path: ${JSON.stringify(marker.navigationPath)}`] : []),
               ...(marker.lightIntensity !== "" ? [`    light_intensity: ${marker.lightIntensity}`] : []),
               ...(marker.lightType ? [`    light_type: ${this._threeLightTypeName(marker.lightType)}`, `    light_radius: ${marker.lightRadius || 1.5}`] : []),
               ...(marker.lightPreset ? [`    light_preset: ${marker.lightPreset}`] : []),
@@ -11103,6 +11103,9 @@ class HomeAssistant3DFloorplanEditor extends HTMLElement {
             ${this._objectField("interactive", index, "entity", "Entity", object.entity, "fan.living_room")}
             ${this._objectSelect("interactive", index, "tap_action", "Tap Action", tapAction, this._interactiveActionOptions())}
             ${this._objectSelect("interactive", index, "hold_action", "Hold Action", holdAction, this._interactiveActionOptions())}
+            ${(tapAction === "navigate" || holdAction === "navigate")
+              ? this._objectField("interactive", index, "navigation_path", "Navigation Path", object.navigation_path || object.navigationPath, "#living-room or /lovelace/room")
+              : ""}
           </div>
           ${this._renderServiceActionFields(index, "tap_action", object.tap_action)}
           ${this._renderServiceActionFields(index, "hold_action", object.hold_action)}
@@ -11113,11 +11116,11 @@ class HomeAssistant3DFloorplanEditor extends HTMLElement {
   }
 
   _interactiveActionOptions() {
-    return [["toggle", "Toggle"], ["more-info", "More info"], ["none", "None"], ["call-service", "Call service"]];
+    return [["toggle", "Toggle"], ["more-info", "More info"], ["navigate", "Navigate"], ["none", "None"], ["call-service", "Call service"]];
   }
 
   _interactiveActionType(action, fallback) {
-    return action && typeof action === "object" && action.action === "call-service" ? "call-service" : (action || fallback);
+    return action && typeof action === "object" ? (action.action || fallback) : (action || fallback);
   }
 
   _renderServiceActionFields(index, actionKey, action) {

--- a/test/navigate-action.test.mjs
+++ b/test/navigate-action.test.mjs
@@ -208,6 +208,36 @@ test("navigation_path is written back out to YAML", () => {
   assert.equal(exported.navigationPath, "#kitchen");
 });
 
+test("hash navigation_path is quoted in final YAML output", () => {
+  const card = makeCard({
+    _activeFloorId: "ground",
+    _floorMarkers: {},
+    _markers: {
+      "light.kitchen": { entityId: "light.kitchen", x: 1, y: 2, navigationPath: "#kitchen" },
+    },
+    _modelDefaultViews: {},
+    _yamlPerformanceSettings: () => [],
+    _yamlAmbientDarkness: () => [],
+    _yamlDefaultView: () => [],
+    _hasMultipleFloors: () => false,
+    _yamlZonesForFloor: () => [],
+    _yamlLightPresets: () => [],
+  });
+  const rows = [{ key: "light.kitchen", entityId: "light.kitchen", name: "Kitchen", primaryDomain: "light" }];
+  assert.match(card._yamlExport(rows), /navigation_path: "#kitchen"/);
+});
+
+test("interactive object editor offers navigate and its path field", () => {
+  const editor = Object.create(Editor.prototype);
+  editor._config = {
+    interactive_objects: [{ object_name: "Door", tap_action: "navigate", navigation_path: "#entry" }],
+  };
+  assert.ok(editor._interactiveActionOptions().some(([value]) => value === "navigate"));
+  const html = editor._renderInteractiveObjectEditors();
+  assert.match(html, /data-object-key="navigation_path"/);
+  assert.match(html, /value="#entry"/);
+});
+
 test("re-tapping the same marker fires no second hashchange (known Bubble caveat)", () => {
   reset();
   const card = makeCard({ _markers: { "light.a": { navigationPath: "#kitchen" } } });


### PR DESCRIPTION
## What changed

- Quote `navigation_path` values in generated YAML so hash targets survive parsing.
- Add `navigate` to interactive-object action choices.
- Show a navigation-path field when either interactive-object action navigates.
- Preserve object-form action types in the editor.
- Add regression coverage for final YAML output and rendered editor controls.

## Why

PR #3 added navigation actions, but hash targets were exported as YAML comments and interactive-object destinations could not be configured in the visual editor.

## Validation

- `node --test` — 20 passing tests
- `git diff --check`