### PR TITLE
release v2.11.0

### DIFF
--- a/Home-Assistant-3D-Floorplan.js
+++ b/Home-Assistant-3D-Floorplan.js
@@ -1,4 +1,4 @@
-﻿const VERSION = "2.10.0";
+﻿const VERSION = "2.11.0";
 class HomeAssistant3DFloorplan extends HTMLElement {
   static getConfigElement() {
     return document.createElement("home-assistant-3d-floorplan-editor");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "home-assistant-3d-floorplan",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "home-assistant-3d-floorplan",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "home-assistant-3d-floorplan",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "![Home Assistant 3D Floorplan preview](images/preview.png)",
   "main": "Home-Assistant-3D-Floorplan.js",
   "scripts": {


### PR DESCRIPTION
## What changed

- Bump the floorplan runtime version to `2.11.0`.
- Align `package.json` and `package-lock.json` with the release version.

## Why

This prepares the navigation-action feature and follow-up configuration fixes from PRs #3 and #4 for a minor release.

## Validation

- `node --test` — 20 passing tests
- `git diff --check`